### PR TITLE
[BIB-131] Fix logins for new users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,11 +1,11 @@
 class User < ActiveRecord::Base
   include Spotlight::User
-  # attr_accessible :email, :password, :password_confirmation if Rails::VERSION::MAJOR < 4
+  attr_accessible :email, :password, :password_confirmation if Rails::VERSION::MAJOR < 4
 # Connects this user object to Blacklights Bookmarks. 
   include Blacklight::User
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
-  devise :omniauthable, :omniauth_providers => [:cas]
+  devise :database_authenticatable, :omniauthable, :omniauth_providers => [:cas]
 
   # Method added by Blacklight; Blacklight uses #to_s on your
   # user class to get a user-displayable login/identifier for


### PR DESCRIPTION
Added in the corresponding change made on DCS to (hopefully) fix the password= error with new accounts
